### PR TITLE
Add Edit and Delete function for Order pages

### DIFF
--- a/pmserver/controllers/orderController.js
+++ b/pmserver/controllers/orderController.js
@@ -91,3 +91,75 @@ exports.create_order = function(req, res) {
 		});
 	}
 };
+
+exports.edit_order = function(req, res) {
+	Order.findById(req.params.id, function(order_err, order) {
+		if (order_err) {
+			return res.send({
+				success: false,
+				code: 400,
+				status: "Order not found",
+				err: order_err
+			});
+		}
+		Item.findById(order.item, function(item_err, item) {
+			if (item_err) {
+				return res.send({
+					success: false,
+					code: 400,
+					status: "Item not found",
+					err: item_err
+				});
+			}
+
+			item.update(req.body, function(item_update_err) {
+				if (item_update_err) {
+					return res.send({
+						success: false,
+						code: 400,
+						status: "Can't update item",
+						err: item_update_err
+					});
+				}
+			});
+		});
+
+		order.update(req.body, function(order_update_err) {
+			if (order_update_err) {
+				return res.send({
+					success: false,
+					code: 400,
+					status: "Can't update order",
+					err: order_update_err
+				});
+			}
+			return res.send({
+				success: true,
+				code: 200,
+				status: "Order update successful"
+			});
+
+		});
+
+	});
+};
+
+exports.delete_order = function(req, res) {
+	Order.remove({
+		_id: req.params.id
+	}, function(err) {
+		if (err) {
+			return res.send({
+				success: false,
+				code: 400,
+				status: err
+			});
+		}
+
+		return res.send({
+			success: true,
+			code: 200,
+			status: "Successfully delete this order"
+		});
+	});
+};

--- a/pmserver/routes/orders.js
+++ b/pmserver/routes/orders.js
@@ -3,10 +3,16 @@ var router = express.Router();
 
 const orderController = require('../controllers/orderController');
 
-/* GET orders listing. */
+// GET orders listing
 router.get('/', orderController.order_list);
 
-// POST user sign up
+// POST create order
 router.post('/', orderController.create_order);
+
+// PUT edit order
+router.put('/:id', orderController.edit_order);
+
+// DELETE delete order
+router.delete('/:id', orderController.delete_order);
 
 module.exports = router;


### PR DESCRIPTION
# Add Edit and Delete function for Order pages

## Edit Function (PUT method):

![wrong order id](https://user-images.githubusercontent.com/14811198/39030095-95e8945a-442d-11e8-8453-fd8e60afdd52.PNG)
Wrong ID on params -> Fail

![no input](https://user-images.githubusercontent.com/14811198/39030098-98e0e13a-442d-11e8-920a-e9158edb63cd.PNG)
No input in update fields -> Success

![order variable only](https://user-images.githubusercontent.com/14811198/39030099-9bcde33e-442d-11e8-9d7c-6b05b1b87801.PNG)
Only changes to Order Model -> Success

![item variables only](https://user-images.githubusercontent.com/14811198/39030102-9debad5e-442d-11e8-8208-541c520224f5.PNG)
Only changes to Item Model -> Success

![order and item variables](https://user-images.githubusercontent.com/14811198/39030103-9feacd2e-442d-11e8-922b-74fb6eaf9858.PNG)
Changes to both Order and Item Model -> Success

## Delete function (DELETE method):

![delete order](https://user-images.githubusercontent.com/14811198/39030105-a1a3acbc-442d-11e8-9663-0b0436e40934.PNG)
Delete this order -> Success